### PR TITLE
added toggle for connecting/disconnecting signals during e-stop

### DIFF
--- a/src/baxter_demo_ui/demo_ui.py
+++ b/src/baxter_demo_ui/demo_ui.py
@@ -133,6 +133,8 @@ class BrrUi(object):
 
         self._navigators = {'left': Navigator('left'),
                            'right': Navigator('right')}
+
+        self._listeners_connected = False
         self._connect_listeners()
 
         self._wheel_ok = True


### PR DESCRIPTION
Fixes a bug that would crash the demo mode if the user attempted to rotate the navigator while the robot is e-stopped
